### PR TITLE
Change webpack config to support use of SystemJS

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -331,8 +331,14 @@ module.exports = function(webpackEnv) {
     module: {
       strictExportPresence: true,
       rules: [
-        // Disable require.ensure as it's not a standard language feature.
-        { parser: { requireEnsure: false } },
+        {
+          parser: {
+            // Disable require.ensure as it's not a standard language feature.
+            requireEnsure: false,
+            // Prevent Webpack from managing use of systemjs
+            system: false
+          }
+        },
 
         // First, run the linter.
         // It's important to do this before Babel processes the JS.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "react-scripts",
+  "name": "@ptv.js/react-scripts",
   "version": "3.4.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/create-react-app.git",
+    "url": "https://github.com/PrometheanTV/create-react-app.git",
     "directory": "packages/react-scripts"
   },
   "license": "MIT",
@@ -12,7 +12,7 @@
     "node": ">=8.10"
   },
   "bugs": {
-    "url": "https://github.com/facebook/create-react-app/issues"
+    "url": "https://github.com/PrometheanTV/create-react-app/issues"
   },
   "files": [
     "bin",


### PR DESCRIPTION
This PR implements the webpack.config.js change required to allow react-scripts to build code that explicitly uses `systemjs`

The path is applied to a branch created from `react-scripts-3.4.1`.

This fork of `react-scripts` is published as `@ptv.js/react-scripts-3.4.1`.
Hopefully by mirroring the upstream version it will be easier to track and pull upstream changes.